### PR TITLE
Support short flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (flag, argv) {
 	argv = argv || process.argv;
 
 	var terminatorPos = argv.indexOf('--');
-	var prefix = /^--/.test(flag) ? '' : '--';
+	var prefix = /^-{1,2}/.test(flag) ? '' : '--';
 	var pos = argv.indexOf(prefix + flag);
 
 	return pos !== -1 && (terminatorPos !== -1 ? pos < terminatorPos : true);

--- a/test.js
+++ b/test.js
@@ -6,6 +6,9 @@ test(t => {
 	t.true(m('--unicorn', ['--foo', '--unicorn', '--bar']), 'optional prefix');
 	t.true(m('unicorn=rainbow', ['--foo', '--unicorn=rainbow', '--bar']));
 	t.true(m('unicorn', ['--unicorn', '--', '--foo']));
+	t.true(m('-u', ['-f', '-u', '-b']));
+	t.true(m('-u', ['-u', '--', '-f']));
 	t.false(m('unicorn', ['--foo', '--', '--unicorn']), 'don\'t match flags after terminator');
 	t.false(m('unicorn', ['--foo']));
+	t.false(m('u', ['-f', '-u', '-b']), 'default prefix is --');
 });


### PR DESCRIPTION
Allow flags to be prefixed with -- or -. The default prefix remains --, irrespective of flag length.

Needed to test for `-w` and `-t` flags in https://github.com/sindresorhus/ava/pull/732.

I suppose this could be considered a breaking change.
