### PR TITLE
Receiving an array of flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,30 @@
 'use strict';
-module.exports = function (flag, argv) {
+module.exports = function (flags, argv) {
 	argv = argv || process.argv;
 
+	var contains = false;
+
+	if (Array.isArray(flags)) {
+		var matches = flags.filter(function (flag) {
+			return containsTheTerm(flag, argv);
+		});
+
+		contains = flags.length === matches.length;
+	} else {
+		contains = containsTheTerm(flags, argv);
+	}
+
+	return contains;
+};
+
+function containsTheTerm(flag, argv) {
 	var terminatorPos = argv.indexOf('--');
 	var prefix = /^-{1,2}/.test(flag) ? '' : '--';
 	var pos = argv.indexOf(prefix + flag);
 
+	if (typeof flag === 'undefined') {
+		return false;
+	}
+
 	return pos !== -1 && (terminatorPos === -1 ? true : pos < terminatorPos);
-};
+}

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,12 @@ hasFlag('-f');
 hasFlag('foo=bar');
 //=> true
 
+hasFlag(['-f', 'unicorn']);
+//=> true
+
+hasFlag(['--unicorn', '--rainbow']);
+//=> false
+
 hasFlag('foo');
 //=> false
 
@@ -50,7 +56,7 @@ Returns a boolean whether the flag exists.
 
 #### flag
 
-Type: `string`
+Type: `string` or `array`
 
 CLI flag to look for. The `--` prefix is optional.
 

--- a/test.js
+++ b/test.js
@@ -8,7 +8,12 @@ test(t => {
 	t.true(m('unicorn', ['--unicorn', '--', '--foo']));
 	t.true(m('-u', ['-f', '-u', '-b']));
 	t.true(m('-u', ['-u', '--', '-f']));
+	t.true(m(['-f', '-u'], ['-u', '-f', '--']));
+	t.true(m(['unicorn', '-f'], ['-f', '--unicorn']));
+	t.true(m(['unicorn=rainbow', '--bar'], ['--foo', '--unicorn=rainbow', '--bar']));
+	t.false(m(['--foo', '--unicorn'], ['-f', '--unicorn']));
 	t.false(m('unicorn', ['--foo', '--', '--unicorn']), 'don\'t match flags after terminator');
+	t.false(m(['unicorn', 'unicorn=rainbow'], ['--foo', '--unicorn=rainbow', '--', '--unicorn']));
 	t.false(m('unicorn', ['--foo']));
 	t.false(m('u', ['-f', '-u', '-b']), 'default prefix is --');
 });


### PR DESCRIPTION
This PR allows the package to receive an array of flags to check if they're in `argv`. But It continues receiving strings as well. For example:

``` js
const hasFlag = require('has-flag');

hasFlag(['-f', 'unicorn']);
//=> true

hasFlag('-f');
//=> true
```

```
$ node foo.js -f --unicorn --foo=bar
```
