### PR TITLE
Don't crash if process.argv is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function (flag, argv) {
-	argv = argv || process.argv;
+	argv = argv || process.argv || [];
 
 	var terminatorPos = argv.indexOf('--');
 	var prefix = /^-{1,2}/.test(flag) ? '' : '--';


### PR DESCRIPTION
`process.argv` is undefined within react-native apps. Adding this fallback will prevent `has-flag` from crashing which in turn allows the usage of packages which use this `has-flag` (at least if the command line arguments are not important).

In my case I would like to use [envalid](https://github.com/af/envalid) with react-native. `envalid` uses `chalk`, which requires `supports-color` which finally uses `has-flag`.